### PR TITLE
Update ZISHGUX.m

### DIFF
--- a/Packages/Kernel/Routines/ZISHGUX.m
+++ b/Packages/Kernel/Routines/ZISHGUX.m
@@ -53,6 +53,10 @@ DELERR ;Trap any $ETRAP error, unwind and return.
  S %ZXDEL=0
  D UNWIND^%ZTER
  Q
+DEL1(%F) ; Delete one file
+ O %F
+ C %F:(DELETE:DESTROY)
+ Q
  ;
 LIST(%ZX1,%ZX2,%ZX3) ;ef,SR. Set local array holding fl names
  ;S Y=$$LIST^ZISH("/dir/","list_root","return_root")


### PR DESCRIPTION
Add entyref DEL1.  Here is a test case for the added code:

kbhaskar@bhaskark:~$ touch /tmp/tmp ; ls -l /tmp/tmp
-rw-r--r-- 1 kbhaskar gtc 0 Jan 29 15:33 /tmp/tmp
kbhaskar@bhaskark:~$ /usr/lib/fis-gtm/V6.2-001_x86_64/gtm -run ^%XCMD 'ZPRINT DEL1^test1:DEL1+3'
DEL1(%F) ; Delete one file
 O %F
 C %F:(DELETE:DESTROY)
 Q
kbhaskar@bhaskark:~$ /usr/lib/fis-gtm/V6.2-001_x86_64/gtm -run ^%XCMD 'D DEL1^test1("/tmp/tmp")'
kbhaskar@bhaskark:~$ ls -l /tmp/tmp
ls: cannot access /tmp/tmp: No such file or directory
kbhaskar@bhaskark:~$
